### PR TITLE
allow symbols, numbers, and uppercase letters in passwords

### DIFF
--- a/src/transformers/cipher.html
+++ b/src/transformers/cipher.html
@@ -17,7 +17,7 @@
     <label for="input-plaintext">Message</label>    
     <textarea id="input-plaintext" class="textt-input" placeholder="Enter text here" rows="5" cols="80"></textarea>
     
-    <label for="input-password">Password (lowercase characters only!)</label>    
+    <label for="input-password">Password</label>    
     <input id="input-password" class="textt-input" type="password" placeholder="Enter password here"/>
 
     <label for="input-modifiedtext">Code</label>

--- a/src/transformers/cipher.js
+++ b/src/transformers/cipher.js
@@ -18,7 +18,7 @@ function transformText(input, password) {
 
    for (let index = 0; index < input.length; index++) {
     let char = input.charCodeAt(index)
-    let shift = password.charCodeAt(index%password.length) - 97 + 1
+    let shift = getShift(password, index)
 
     let encChar = ''
     if (char >=48 && char <= 57) {
@@ -66,4 +66,14 @@ function encryptSymbol(char, shift) {
   
 function encrypt(char, shift, len, start) {
   return ((char + (shift%len) - start) % len) + start
+}
+
+function getShift(password, index) {
+  let code = password.charCodeAt(index%password.length)
+  if (code >= 97 && code <= 122) {
+    // legacy, for backwards compatibility
+    return password.charCodeAt(index%password.length) - 97 + 1
+  } else {
+    return password.charCodeAt(index%password.length)
+  }
 }

--- a/src/transformers/decipher.html
+++ b/src/transformers/decipher.html
@@ -17,7 +17,7 @@
     <label for="input-plaintext">Code</label>    
     <textarea id="input-plaintext" class="textt-input" placeholder="Enter text here" rows="5" cols="80"></textarea>
     
-    <label for="input-password">Password (lowercase characters only!)</label>    
+    <label for="input-password">Password</label>    
     <input id="input-password" class="textt-input" type="password" placeholder="Enter password here"/>
 
     <label for="input-modifiedtext">Message</label>

--- a/src/transformers/decipher.js
+++ b/src/transformers/decipher.js
@@ -18,7 +18,7 @@ function transformText(input, password) {
 
    for (let index = 0; index < input.length; index++) {
     let char = input.charCodeAt(index)
-    let shift = password.charCodeAt(index%password.length) - 97 + 1
+    let shift = getShift(password, index)
 
     let decChar = ''
     if (char >=48 && char <= 57) {
@@ -66,4 +66,14 @@ function decryptUppercase(char, shift) {
     
 function decrypt(char, shift, len, start) {
     return ((char + (len-(shift%len)) - start) % len) + start
+}
+
+function getShift(password, index) {
+  let code = password.charCodeAt(index%password.length)
+  if (code >= 97 && code <= 122) {
+    // legacy, for backwards compatibility
+    return password.charCodeAt(index%password.length) - 97 + 1
+  } else {
+    return password.charCodeAt(index%password.length)
+  }
 }


### PR DESCRIPTION
This PR updates how the shift amount is computed for the cipher pages. The old behavior for lowercase letters is preserved (incrementing shift starting at `a = 1`) . For all other characters, the character code value is used without modification.

Now passwords can contain characters other than `[a-z]`. Previously encrypted messages will can still be decrypted.